### PR TITLE
Make a version 1.0.2 for valeriyvan/jpeg.git allFixesMerged branch

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     {
       "identity" : "jpeg",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:valeriyvan/jpeg.git",
+      "location" : "https://github.com/valeriyvan/jpeg.git",
       "state" : {
-        "branch" : "allFixesMerged",
-        "revision" : "6ab5fffa49626116ff6b46510fe9828b71b708af"
+        "revision" : "6ab5fffa49626116ff6b46510fe9828b71b708af",
+        "version" : "1.0.2"
       }
     },
     {
@@ -39,7 +39,7 @@
     {
       "identity" : "swift-png",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:kelvin13/swift-png.git",
+      "location" : "https://github.com/kelvin13/swift-png.git",
       "state" : {
         "revision" : "075dfb248ae327822635370e9d4f94a5d3fe93b2",
         "version" : "4.0.2"

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/kelvin13/swift-png.git", from: "4.0.2"),
-    .package(url: "https://github.com/valeriyvan/jpeg.git", branch: "allFixesMerged"),
+    .package(url: "https://github.com/valeriyvan/jpeg.git", from: "1.0.2"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.9.0"),
     .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.4"),


### PR DESCRIPTION
Make a version 1.0.2 for valeriyvan/jpeg.git allFixesMerged branch to make SPM consider version as stable

SPM doesn't allow package to be used as dependency if it depends on unstable version. 
Version which depends on branch is variable and considered unstable.