### PR TITLE
Use module aliasing to solve build error while using original JPEG Swift package

### DIFF
--- a/.github/workflows/build-run-tests-macos.yml
+++ b/.github/workflows/build-run-tests-macos.yml
@@ -12,8 +12,9 @@ on:
 jobs:
   build:
 
-    runs-on:  macOS-12 # used to be macos-latest
-                       # look https://github.com/actions/runner-images/issues/6384
+    runs-on:  macOS-13 # used to be macos-latest
+                       # look https://github.com/actions/runner-images/issues/6384 for info 
+                       # why it was changed from macos-latest to macOS-12
 
     steps:
     - uses: actions/checkout@v3

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,16 +3,16 @@
     {
       "identity" : "jpeg",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/valeriyvan/jpeg.git",
+      "location" : "https://github.com/tayloraswift/jpeg.git",
       "state" : {
-        "revision" : "6ab5fffa49626116ff6b46510fe9828b71b708af",
-        "version" : "1.0.2"
+        "branch" : "master",
+        "revision" : "fc21d193b85ad8593b0a894b1dec9bef56254058"
       }
     },
     {
       "identity" : "swift-algorithms",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:apple/swift-algorithms.git",
+      "location" : "https://github.com/apple/swift-algorithms.git",
       "state" : {
         "revision" : "b14b7f4c528c942f121c8b860b9410b2bf57825e",
         "version" : "1.0.0"
@@ -21,7 +21,7 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:apple/swift-argument-parser.git",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
         "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
         "version" : "1.1.4"
@@ -39,7 +39,7 @@
     {
       "identity" : "swift-png",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kelvin13/swift-png.git",
+      "location" : "https://github.com/tayloraswift/swift-png.git",
       "state" : {
         "revision" : "075dfb248ae327822635370e9d4f94a5d3fe93b2",
         "version" : "4.0.2"
@@ -48,7 +48,7 @@
     {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:pointfreeco/swift-snapshot-testing.git",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
         "revision" : "696b86a6d151578bca7c1a2a3ed419a5f834d40f",
         "version" : "1.13.0"
@@ -66,7 +66,7 @@
     {
       "identity" : "swiftlintplugin",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:lukepistrol/SwiftLintPlugin.git",
+      "location" : "https://github.com/lukepistrol/SwiftLintPlugin.git",
       "state" : {
         "revision" : "67d09110cc967b9d393a5313b3b21c1b0be59adb",
         "version" : "0.0.4"

--- a/Package.swift
+++ b/Package.swift
@@ -57,6 +57,8 @@ let package = Package(
                 // alias solves build error
                 // error: multiple products named 'unit-test' in: 'jpeg' (at '****/jpeg'), 'swift-png' (from 'https://github.com/tayloraswift/swift-png.git')
                 // https://github.com/tayloraswift/jpeg/issues/4
+                // https://forums.swift.org/t/product-names-from-different-packages-collide-if-packages-are-used-as-dependencies-in-same-package/60178
+                // Uses Swift 5.7 feature https://github.com/apple/swift-evolution/blob/main/proposals/0339-module-aliasing-for-disambiguation.md
             ],
             plugins: plugins
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,8 @@
 import PackageDescription
 
 var dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/kelvin13/swift-png.git", from: "4.0.2"),
-    .package(url: "https://github.com/valeriyvan/jpeg.git", from: "1.0.2"),
+    .package(url: "https://github.com/tayloraswift/swift-png.git", from: "4.0.2"), // try upgrade to latest 4.4.1
+    .package(url: "https://github.com/tayloraswift/jpeg.git", revision: "fc21d193b85ad8593b0a894b1dec9bef56254058"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.13.0"),
     .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.4"),
@@ -53,7 +53,10 @@ let package = Package(
                 "Geometrize",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "PNG", package: "swift-png"),
-                .product(name: "JPEG", package: "jpeg")
+                .product(name: "JPEG", package: "jpeg", moduleAliases: ["JPEG": "SwiftJPEG"])
+                // alias solves build error
+                // error: multiple products named 'unit-test' in: 'jpeg' (at '****/jpeg'), 'swift-png' (from 'https://github.com/tayloraswift/swift-png.git')
+                // https://github.com/tayloraswift/jpeg/issues/4
             ],
             plugins: plugins
         ),


### PR DESCRIPTION
Uses Swift 5.7 feature https://github.com/apple/swift-evolution/blob/main/proposals/0339-module-aliasing-for-disambiguation.md

Solves old issue https://forums.swift.org/t/product-names-from-different-packages-collide-if-packages-are-used-as-dependencies-in-same-package/60178