### PR TITLE
upgrade png, jpeg dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,7 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tayloraswift/jpeg.git",
       "state" : {
-        "revision" : "fc21d193b85ad8593b0a894b1dec9bef56254058"
+        "revision" : "fc21d193b85ad8593b0a894b1dec9bef56254058",
+        "version" : "1.1.0"
       }
     },
     {
@@ -13,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-algorithms.git",
       "state" : {
-        "revision" : "b14b7f4c528c942f121c8b860b9410b2bf57825e",
-        "version" : "1.0.0"
+        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+        "version" : "1.2.0"
       }
     },
     {
@@ -22,8 +23,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
-        "version" : "1.1.4"
+        "revision" : "46989693916f56d1186bd59ac15124caef896560",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-hash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tayloraswift/swift-hash",
+      "state" : {
+        "revision" : "c7ba0cde5eb63042c2196b02b65a770101c1ac11",
+        "version" : "0.5.0"
       }
     },
     {
@@ -40,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tayloraswift/swift-png.git",
       "state" : {
-        "revision" : "075dfb248ae327822635370e9d4f94a5d3fe93b2",
-        "version" : "4.0.2"
+        "revision" : "4553010a4d293831627c15635fecabc788b9bebc",
+        "version" : "4.4.1"
       }
     },
     {
@@ -49,26 +59,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "696b86a6d151578bca7c1a2a3ed419a5f834d40f",
-        "version" : "1.13.0"
+        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
+        "version" : "1.16.0"
       }
     },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
-      }
-    },
-    {
-      "identity" : "swiftlintplugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lukepistrol/SwiftLintPlugin.git",
-      "state" : {
-        "revision" : "67d09110cc967b9d393a5313b3b21c1b0be59adb",
-        "version" : "0.0.4"
+        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
+        "version" : "510.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,8 @@
 import PackageDescription
 
 var dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/tayloraswift/swift-png.git", from: "4.0.2"), // try upgrade to latest 4.4.1
-    .package(url: "https://github.com/tayloraswift/jpeg.git", revision: "fc21d193b85ad8593b0a894b1dec9bef56254058"),
+    .package(url: "https://github.com/tayloraswift/swift-png.git", from: "4.4.1"),
+    .package(url: "https://github.com/tayloraswift/jpeg.git", from: "1.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.13.0"),
     .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.4"),
@@ -18,13 +18,13 @@ var dependencies: [Package.Dependency] = [
 #endif
 
 let package = Package(
-    
+
     name: "swift-geometrize",
-    
+
     platforms: [
         .macOS(.v10_15), .iOS(.v14)
     ],
-    
+
     products: [
         .library(
             name: "Geometrize",
@@ -35,9 +35,9 @@ let package = Package(
             targets: ["geometrize-cli"]
         )
     ],
-    
+
     dependencies: dependencies,
-    
+
     targets: [
         .target(
             name: "Geometrize",
@@ -77,5 +77,5 @@ let package = Package(
             plugins: plugins
         )
     ]
-    
+
 )

--- a/Sources/geometrize-cli/main.swift
+++ b/Sources/geometrize-cli/main.swift
@@ -26,7 +26,7 @@ let width, height: Int
 
 switch inputUrl.pathExtension.lowercased() {
 case "png":
-    guard let image: PNG.Data.Rectangular = try .decompress(path: inputUrl.path) else {
+    guard let image: PNG.Image = try .decompress(path: inputUrl.path) else {
         print("Cannot read or decode input file \(inputUrl.path).")
         exit(1)
     }


### PR DESCRIPTION
also fixes compilation error due to missing `public` ACL on compatibility typealias in swift-png (fixed separately in https://github.com/tayloraswift/swift-png/commit/14a720bfcf1b0660dc63979d55d218babc8d651f )