### PR TITLE
Update build-run-tests-macos.yml

### DIFF
--- a/.github/workflows/build-run-tests-macos.yml
+++ b/.github/workflows/build-run-tests-macos.yml
@@ -16,9 +16,12 @@ jobs:
                        # why it was changed from macos-latest to macOS-12
 
     steps:
-    - uses: swift-actions/setup-swift@v2
-    - name: Check out repository code
+    - name: Checkout
       uses: actions/checkout@v4
+    - name: Select Xcode Version
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '16.2'
     - name: Build
       run: swift build -v
     - name: Run tests


### PR DESCRIPTION
Added step to choose Xcode 16.2.
Latest Xcode started to fail to run SwiftLint plugin https://github.com/lukepistrol/SwiftLintPlugin/issues/25.
And it seems something like that happened with 15.4 used before.
Therefore the change.